### PR TITLE
Prevent reorder_studies from dropping rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epireview
 Title: Tools to update and summarise the latest pathogen data from the Pathogen Epidemiology Review Group (PERG)
-Version: 1.2.7
+Version: 1.2.8
 Authors@R: c(
     person("Rebecca", "Nash", email = "r.nash@imperial.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-5213-4364")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+* epireview 1.2.8
+* BUG FIX: Fixes #73 which caused rows of the params dataset to be dropped during if reordering the population  
+country was NA.
+* FEATURE: reorder_studies can now reorder by any column in the params dataset
+
 * epireview 1.2.7
 
 * FEATURE: filter_df_for_metamean now includes rows with uncertainty types introduced

--- a/R/forest_plot.R
+++ b/R/forest_plot.R
@@ -67,8 +67,10 @@ forest_plot <- function(df, facet_by = NA, shape_by = NA, col_by = NA,
     geom_point(aes(x = .data[['mid']],
                    y = .data[['article_label']])) +
     geom_errorbar(
-      aes(xmin = .data[['low']], xmax = .data[['high']], y = .data[['article_label']],
-          lty = .data[['uncertainty_type']])
+      aes(
+        xmin = .data[['low']], xmax = .data[['high']], 
+        y = .data[['article_label']],
+        lty = .data[['uncertainty_type']])
     ) +
     scale_linetype_manual(values = lty_map, breaks = "Range**") +
     ##scale_y_discrete(breaks = df$article_label, labels = df$article_label) +
@@ -88,7 +90,7 @@ forest_plot <- function(df, facet_by = NA, shape_by = NA, col_by = NA,
     ## as defined in epireview
     ## if neither is provided, use the default palette
     if (!is.na(shp_palette)) {
-      p <- p + scale_shape_manual(values = shp_palette)
+      p <- p + scale_shape_manual(values = shp_palette, na.value = 4)
     } else {
       shp_palette <- shape_palette(shape_by)
       if (! is.null(shp_palette)) {
@@ -106,7 +108,8 @@ forest_plot <- function(df, facet_by = NA, shape_by = NA, col_by = NA,
   if(!is.na(unique_label)){
     ## Check that the provided unique_label is the correct length:
     if (length(unique_label) != length(df$article_label)) {
-      stop("The length of 'unique_label' must match the number of unique labels in the data frame.")
+      stop("The length of 'unique_label' must match the number of unique labels 
+        in the data frame.")
     } else {
       p <- p + scale_y_discrete(labels = unique_label)
     }
@@ -118,7 +121,7 @@ forest_plot <- function(df, facet_by = NA, shape_by = NA, col_by = NA,
     ## as defined in epireview
     ## if neither is provided, use the default palette
     if (!is.na(col_palette)) {
-      p <- p + scale_color_manual(values = col_palette)
+      p <- p + scale_color_manual(values = col_palette, na.value = "gray")
     } else {
       col_palette <- color_palette(col_by)
       if (! is.null(col_palette)) {

--- a/R/reorder_studies.R
+++ b/R/reorder_studies.R
@@ -22,7 +22,7 @@
 #' reorder_studies(param_pm_uncertainty(rt))
 #' 
 #'
-reorder_studies <- function(df) {
+reorder_studies <- function(df, reorder_by = "population_country") {
 
   if (! "mid" %in% colnames(df)) {
     stop(
@@ -34,10 +34,10 @@ reorder_studies <- function(df) {
   ## This will add NA as a valid factor level that is put at the end by
   ## default. So rows will not be dropped if they have NA in the 
   ## population_country. However note that you cannot then use is.na to check
-  ## for NAs in this column. You should use df$population_country %in% NA to
+  ## for NAs in this column. You should use df[[reorder_by]] %in% NA to
   ## subset the data frame.
-  df$population_country <- addNA(df$population_country, ifany = TRUE)
-  res <- by(df, df$population_country, function(x) {
+  df[[reorder_by]] <- addNA(df[[reorder_by]], ifany = TRUE)
+  res <- by(df, df[[reorder_by]], function(x) {
     ## By default order puts NAs at the end
     x[order(x$mid), ]
   })
@@ -49,7 +49,7 @@ reorder_studies <- function(df) {
     levels = unique(df$article_label, ordered = TRUE)
   )
   ## unfactorise the population_country column
-  df2$population_country <- as.character(df2$population_country)
+  df[[reorder_by]] <- as.character(df[[reorder_by]])
 
   df
 }

--- a/R/reorder_studies.R
+++ b/R/reorder_studies.R
@@ -48,6 +48,8 @@ reorder_studies <- function(df) {
   df$article_label <- factor(df$article_label,
     levels = unique(df$article_label, ordered = TRUE)
   )
-  
+  ## unfactorise the population_country column
+  df2$population_country <- as.character(df2$population_country)
+
   df
 }

--- a/R/reorder_studies.R
+++ b/R/reorder_studies.R
@@ -11,6 +11,8 @@
 #' forest plot functions (e.g. \code{\link{forest_plot_rt}}).
 #' 
 #' @param df The input dataframe to be reordered
+#' @param reorder_by character. The name of the column to reorder the data by. 
+#' Default is "population_country"
 #' @return The reordered dataframe
 #' @export
 #' @seealso \code{\link{forest_plot_rt}}  \code{\link{forest_plot_r0}}
@@ -28,6 +30,12 @@ reorder_studies <- function(df, reorder_by = "population_country") {
     stop(
       "mid column not found in the data frame, did you forget to call 
       param_pm_uncertainty?",
+      call. = FALSE
+    )
+  }
+  if (! reorder_by %in% colnames(df)) {
+    stop(
+      paste0(reorder_by, " column not found in the data frame"),
       call. = FALSE
     )
   }

--- a/R/reorder_studies.R
+++ b/R/reorder_studies.R
@@ -17,7 +17,7 @@
 #' @examples
 #' ebola <- load_epidata("ebola")
 #' params <- ebola$params
-#' rt <- params[params$parameter_type == "Reproduction number (Effective, Re)", ]
+#' rt <- params[params$parameter_type == "Reproduction number (Effective, Re)",]
 #' 
 #' reorder_studies(param_pm_uncertainty(rt))
 #' 
@@ -26,11 +26,17 @@ reorder_studies <- function(df) {
 
   if (! "mid" %in% colnames(df)) {
     stop(
-      "mid column not found in the data frame, did you forget to call param_pm_uncertainty?",
+      "mid column not found in the data frame, did you forget to call 
+      param_pm_uncertainty?",
       call. = FALSE
     )
   }
-
+  ## This will add NA as a valid factor level that is put at the end by
+  ## default. So rows will not be dropped if they have NA in the 
+  ## population_country. However note that you cannot then use is.na to check
+  ## for NAs in this column. You should use df$population_country %in% NA to
+  ## subset the data frame.
+  df$population_country <- addNA(df$population_country, ifany = TRUE)
   res <- by(df, df$population_country, function(x) {
     ## By default order puts NAs at the end
     x[order(x$mid), ]

--- a/man/reorder_studies.Rd
+++ b/man/reorder_studies.Rd
@@ -4,10 +4,13 @@
 \alias{reorder_studies}
 \title{Reorder articles based on parameter value}
 \usage{
-reorder_studies(df)
+reorder_studies(df, reorder_by = "population_country")
 }
 \arguments{
 \item{df}{The input dataframe to be reordered}
+
+\item{reorder_by}{character. The name of the column to reorder the data by.
+Default is "population_country"}
 }
 \value{
 The reordered dataframe
@@ -26,7 +29,7 @@ forest plot functions (e.g. \code{\link{forest_plot_rt}}).
 \examples{
 ebola <- load_epidata("ebola")
 params <- ebola$params
-rt <- params[params$parameter_type == "Reproduction number (Effective, Re)", ]
+rt <- params[params$parameter_type == "Reproduction number (Effective, Re)",]
 
 reorder_studies(param_pm_uncertainty(rt))
 

--- a/tests/testthat/test_reorder_studies.R
+++ b/tests/testthat/test_reorder_studies.R
@@ -1,5 +1,5 @@
 test_that("reorder_studies correctly reorders the data frame", {
-  # Create a sample data frame; value is NA bit bounds are provided
+  # Create a sample data frame; value is NA but bounds are provided
   df <- data.frame(
     parameter_value = c(10, 20, NA, 30, 15),
     parameter_lower_bound = c(5, 15, 20, 25, 10),
@@ -23,6 +23,28 @@ test_that("reorder_studies correctly reorders the data frame", {
   df <- param_pm_uncertainty(df)
   df_reordered <- reorder_studies(df)
   expect_equal(
-    levels(df_reordered$article_label), c("e", "a", "c","b", "d"))
+    levels(df_reordered$article_label), c("e", "a", "c","b", "d")
+  )
+
+  ## Test with NAs present in the reorder_by column
+  df <- data.frame(
+    parameter_value = c(10, 20, NA, 30, 15),
+    parameter_lower_bound = c(5, 15, 20, 25, 10),
+    parameter_upper_bound = c(15, 25, 30, 35, 20),
+    population_country = c("c1", "c2", NA, "c2", "c1"),
+    article_label = c("a", "b", "c", "d", "e")
+  )
+  df <- param_pm_uncertainty(df)
+  df_reordered <- reorder_studies(df)
+  expect_equal(
+    levels(df_reordered$article_label), c("a", "e", "b", "d", "c")
+  )
+
+  ## Reorder by a different column
+  df$new_column <- c("A", "A", "B", "A", "A")
+  df_reordered <- reorder_studies(df, "new_column")
+  expect_equal(
+    levels(df_reordered$article_label), c("a", "e", "b", "d", "c")
+  )
 
 })


### PR DESCRIPTION
This PR fixes #73 where reorder_studies was causing rows to be dropped when the column used to order studies contained NA. To fix this, I have edited the code so that NA values are treated as factor levels.
Additionally, 
- I have modified the code so that reorder_studies accepts as an argument the column name to be used for reordering. 
- I have modified forest_plot to set explicit values for NAs in columns mapped to colour or shape aesthetic.

To test this PR,  do the following
```
ebola <- load_epidata("ebola")
params <- ebola$params
si <- params[params$parameter_type %in% "Human delay - serial interval", ]
## Retain only the first six rows so that fix is easier to see
si <- head(si)
si$population_country[1] <- NA
sio <- reorder_studies(param_pm_uncertainty(si))
## sio should also have 6 rows
dim(sio)
## Also check the plots
forest_plot_serial_interval(si, col_by = "population_country")
```

**Checklist**:

 - [ X] I have added new dependencies in `DESCRIPTION`
 - [ X] I have bumped the version number in `DESCRIPTION`
 - [ X] I have updated the `NEWS.md`
 - [ X] I have added unit tests using `testthat`
 - [ X] I have checked that the package can install locally using `devtools::install_local("<path-to-epireview>")`
 - [ X] I have added documentation where required
 - [ X] My documentation includes examples of how to use the function
 - [ NA] If necessary, I have updated [`priority-pathogens`](https://github.com/mrc-ide/priority-pathogens)
