### PR TITLE
Case-insensitive argument to load_epidata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epireview
 Title: Tools to update and summarise the latest pathogen data from the Pathogen Epidemiology Review Group (PERG)
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(
     person("Rebecca", "Nash", email = "r.nash@imperial.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-5213-4364")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# epireview 1.3.3
+
+* FEATURE: The argument to load_epidata is made case-insensitive. Addresses #96
+
 # epireview 1.3.2
 
 * BUG-FIX: Fixes #86 by removing a duplicated row. Also fixes an incorrectly entered method type for CFR, and incorrectly

--- a/R/data.R
+++ b/R/data.R
@@ -16,7 +16,7 @@
 priority_pathogens <- function() {
 
   data.frame(
-    pathogen = c("marburg", "ebola","lassa"),
+    pathogen = c("marburg", "ebola", "lassa"),
     articles_screened = c(4460, 9563,5414),
     articles_extracted = c(42, 520,157),
     doi = c("10.1016/S1473-3099(23)00515-7", "10.1101/2024.03.20.24304571", "10.1101/2024.03.23.24304596"),

--- a/R/load_epidata.R
+++ b/R/load_epidata.R
@@ -70,10 +70,9 @@ short_parameter_type <- function(x, parameter_type_full, parameter_type_short) {
 #' data.frame. See \code{\link{short_parameter_type}} for more details.
 #'
 #' @param pathogen name of pathogen. Must be one of the priority pathogens
-#' exactly as specified in the package. You can get a list of the
-#' priority pathogens currently included in the package by calling
-#' @seealso \code{\link{load_epidata}}
-#'
+#' You can get a list of the
+#' priority pathogens currently included in the package by calling the function
+#' \code{\link{priority_pathogens}}.
 #' @param mark_multiple logical. If TRUE, multiple studies from the same
 #' author in the same year will be marked with a suffix to distinguish them.
 #' @return a list of length 4. The first element is a data.frame called "articles"
@@ -91,6 +90,7 @@ short_parameter_type <- function(x, parameter_type_full, parameter_type_short) {
 #' @export
 load_epidata <- function(pathogen, mark_multiple = TRUE) {
 
+  pathogen <- tolower(pathogen)
   assert_pathogen(pathogen)
 
   articles <- suppressWarnings(load_epidata_raw(pathogen, "article"))

--- a/man/append_new_entry_to_table.Rd
+++ b/man/append_new_entry_to_table.Rd
@@ -8,8 +8,9 @@ append_new_entry_to_table(pathogen, table, new_row, validate = TRUE)
 }
 \arguments{
 \item{pathogen}{name of pathogen. Must be one of the priority pathogens
-exactly as specified in the package. You can get a list of the
-priority pathogens currently included in the package by calling}
+You can get a list of the
+priority pathogens currently included in the package by calling the function
+\code{\link{priority_pathogens}}.}
 
 \item{table}{the table to be loaded. Must be one of
 "article", "parameter", "outbreak", or "model"}

--- a/man/article_column_type.Rd
+++ b/man/article_column_type.Rd
@@ -8,8 +8,9 @@ article_column_type(pathogen)
 }
 \arguments{
 \item{pathogen}{name of pathogen. Must be one of the priority pathogens
-exactly as specified in the package. You can get a list of the
-priority pathogens currently included in the package by calling}
+You can get a list of the
+priority pathogens currently included in the package by calling the function
+\code{\link{priority_pathogens}}.}
 }
 \value{
 A list of column types for the article data frame

--- a/man/get_table_field_options.Rd
+++ b/man/get_table_field_options.Rd
@@ -12,8 +12,9 @@ get_table_field_options(
 }
 \arguments{
 \item{pathogen}{name of pathogen. Must be one of the priority pathogens
-exactly as specified in the package. You can get a list of the
-priority pathogens currently included in the package by calling}
+You can get a list of the
+priority pathogens currently included in the package by calling the function
+\code{\link{priority_pathogens}}.}
 
 \item{table}{the table to be loaded. Must be one of
 "article", "parameter", "outbreak", or "model"}

--- a/man/load_epidata.Rd
+++ b/man/load_epidata.Rd
@@ -8,8 +8,9 @@ load_epidata(pathogen, mark_multiple = TRUE)
 }
 \arguments{
 \item{pathogen}{name of pathogen. Must be one of the priority pathogens
-exactly as specified in the package. You can get a list of the
-priority pathogens currently included in the package by calling}
+You can get a list of the
+priority pathogens currently included in the package by calling the function
+\code{\link{priority_pathogens}}.}
 
 \item{mark_multiple}{logical. If TRUE, multiple studies from the same
 author in the same year will be marked with a suffix to distinguish them.}
@@ -35,7 +36,4 @@ This function will read in the pathogen-specific articles and
 parameters files and join them into a data.frame. This function also
 creates user-friendly short labels for the "parameter_type" column in params
 data.frame. See \code{\link{short_parameter_type}} for more details.
-}
-\seealso{
-\code{\link{load_epidata}}
 }

--- a/man/load_epidata_raw.Rd
+++ b/man/load_epidata_raw.Rd
@@ -11,8 +11,9 @@ load_epidata_raw(
 }
 \arguments{
 \item{pathogen}{name of pathogen. Must be one of the priority pathogens
-exactly as specified in the package. You can get a list of the
-priority pathogens currently included in the package by calling}
+You can get a list of the
+priority pathogens currently included in the package by calling the function
+\code{\link{priority_pathogens}}.}
 
 \item{table}{the table to be loaded. Must be one of
 "article", "parameter", "outbreak", or "model"}

--- a/tests/testthat/test_data_load_and_prep.R
+++ b/tests/testthat/test_data_load_and_prep.R
@@ -1,5 +1,8 @@
 test_that("load_epidata loads data as expected", {
 
+  ## Check that load_epidata argument is case insensitive
+  expect_no_error(suppressMessages(suppressWarnings(load_epidata("Marburg"))))
+  expect_no_error(suppressMessages(suppressWarnings(load_epidata("marBURG"))))
   # Check that the data loads without error
   expect_no_error(suppressMessages(suppressWarnings(load_epidata("marburg"))))
 


### PR DESCRIPTION
As requested in #96 
I turn the provided argument to lower case before running validity checks.
I have updated the tests, documentation and bumped up version number and NEWS.
To test this PR, checkout the branch and do
```
devtools::check()
```
You should see no errors, warnings or notes.
Further, if you either install and load the package or do, 
```
devtools::load_all()
```

then, the following should work

```
load_epidata('ebola')
load_epidata('EBOLA')
load_epidata('eBoLa')
```