### PR TITLE
Citation for epireview

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     person("Anne", "Cori", role = "aut", comment = c(ORCID = "0000-0002-8443-9162")),
     person("Thomas", "Rawson", role = "aut", comment = c(ORCID = "0000-0001-8182-4279")),
     person("Patrick", "Doohan", role = "aut", comment = c(ORCID = "0000-0001-8076-1106")),
-    person("Tristan", "Naidoo", role = "aut", comment = c(ORCID = 0000-0001-9970-2421)),
+    person("Tristan", "Naidoo", role = "aut", comment = c(ORCID = "0000-0001-9970-2421")),
     person("Shazia", "Ruybal-Pesántez", role = "aut", comment = c(ORCID = "0000-0002-0495-179X")))
 Description: Contains the latest open access pathogen data from the Pathogen Epidemiology Review Group (PERG). Tools are available to update pathogen databases with new peer-reviewed data as it becomes available, and to summarise the latest data using tables and figures.
 License: MIT + file LICENSE

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,30 @@
+citHeader("To cite {epireview} in publications, please use:")
+
+bibentry(
+  "Manual",
+  title = "epireview: Tools to update and summarise the latest pathogen data from the Pathogen Epidemiology Review Group (PERG)",
+  author = c(
+    person("Tristan", "Naidoo", role = "aut", comment = c(ORCID = "0000-0001-9970-2421")),
+    person("Rebecca", "Nash", email = "r.nash@imperial.ac.uk", role = "aut",
+           comment = c(ORCID = "0000-0002-5213-4364")),
+    person("Christian", "Morgenstern", email = "c.morgenstern@imperial.ac.uk", role = "aut",
+           comment = c(ORCID = "0000-0003-3735-1130")),
+    person("Patrick", "Doohan", role = "aut", comment = c(ORCID = "0000-0001-8076-1106")),
+    person("Ruth", "McCabe", role = "aut", comment = c(ORCID = "0000-0002-6368-9103")),
+    person("Joshua", "Lambert", role = "aut", comment = c(ORCID = "0000-0001-5218-3046")),
+    person("Richard", "Sheppard", email = "richard.sheppard11@imperial.ac.uk", role = "aut"),    
+    person("Cosmo", "Santoni", email = "cosmo.santoni@imperial.ac.uk", role = "aut"),
+    person("Thomas", "Rawson", role = "aut", comment = c(ORCID = "0000-0001-8182-4279")),
+    person("Shazia", "Ruybal-Pesántez", role = "aut", comment = c(ORCID = "0000-0002-0495-179X")),
+    person("Juliette H", "Unwin", role = "aut"),
+    person("Gina", "Cuomo-Dannenburg", role = "aut", comment = c(ORCID = "0000-0001-6821-0352")),
+    person("Kelly", "McCain", role = "aut", comment = c(ORCID = "0000-0003-2393-2217")),    
+    person("Joseph", "Hicks", email = "j.hicks@imperial.ac.uk", role = "aut"),
+    person("Anne", "Cori", role = "aut", comment = c(ORCID = "0000-0002-8443-9162")),
+    person("Sangeeta", "Bhatia", email = "s.bhatia@imperial.ac.uk", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0001-6525-101X"))
+  ),
+  year = "2025",
+  note = "R package version 1.4.4",
+  url = "https://github.com/mrc-ide/epireview"
+)

--- a/man/epireview-package.Rd
+++ b/man/epireview-package.Rd
@@ -33,7 +33,7 @@ Authors:
   \item Anne Cori (\href{https://orcid.org/0000-0002-8443-9162}{ORCID})
   \item Thomas Rawson (\href{https://orcid.org/0000-0001-8182-4279}{ORCID})
   \item Patrick Doohan (\href{https://orcid.org/0000-0001-8076-1106}{ORCID})
-  \item Tristan Naidoo (-12392)
+  \item Tristan Naidoo (\href{https://orcid.org/0000-0001-9970-2421}{ORCID})
   \item Shazia Ruybal-Pesántez (\href{https://orcid.org/0000-0002-0495-179X}{ORCID})
 }
 


### PR DESCRIPTION
As discussed with the group, I have created a citation file so that the package can be properly cited.
The DESCRIPTION file was missing quotes around Tristan's orcid, so I have fixed that as well.
This PR does not warrant an update of the version number and no new tests are needed.
I have checked the citation and we get the following desired output:
```
> citation("epireview")
To cite {epireview} in publications, please use:

  Naidoo T, Nash R, Morgenstern C, Doohan P, McCabe R, Lambert J,
  Sheppard R, Santoni C, Rawson T, Ruybal-Pesántez S, Unwin J,
  Cuomo-Dannenburg G, McCain K, Hicks J, Cori A, Bhatia S (2025).
  _epireview: Tools to update and summarise the latest pathogen data
  from the Pathogen Epidemiology Review Group (PERG)_. R package
  version 1.4.4, <https://github.com/mrc-ide/epireview>.

A BibTeX entry for LaTeX users is

  @Manual{,
    title = {epireview: Tools to update and summarise the latest pathogen data from the Pathogen Epidemiology Review Group (PERG)},
    author = {Tristan Naidoo and Rebecca Nash and Christian Morgenstern and Patrick Doohan and Ruth McCabe and Joshua Lambert and Richard Sheppard and Cosmo Santoni and Thomas Rawson and Shazia Ruybal-Pesántez and Juliette H Unwin and Gina Cuomo-Dannenburg and Kelly McCain and Joseph Hicks and Anne Cori and Sangeeta Bhatia},
    year = {2025},
    note = {R package version 1.4.4},
    url = {https://github.com/mrc-ide/epireview},
  }
```